### PR TITLE
fix: from bridge.framework.django import configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ pip install python-bridge
 ### Usage
 Add the following code to the end of your `settings.py` file (or `DJANGO_SETTINGS_MODULE`):
 ```python
-from bridge.framework.django import configure
+from bridge import django
 
-configure(locals())
+django.configure(locals())
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install python-bridge
 ### Usage
 Add the following code to the end of your `settings.py` file (or `DJANGO_SETTINGS_MODULE`):
 ```python
-from bridge.django import configure
+from bridge.framework.django import configure
 
 configure(locals())
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,9 +23,9 @@ Add the following code to the end of your `settings.py` file (or `DJANGO_SETTING
 ```python
 # Configure infrastructure with Bridge.
 # All other settings should be above these lines.
-from bridge.framework.django import configure
+from bridge import django
 
-configure(locals())
+django.configure(locals())
 ```
 
 The next time you start up your application, bridge will create and configure local infrastructure for you:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,7 +23,7 @@ Add the following code to the end of your `settings.py` file (or `DJANGO_SETTING
 ```python
 # Configure infrastructure with Bridge.
 # All other settings should be above these lines.
-from bridge.django import configure
+from bridge.framework.django import configure
 
 configure(locals())
 ```


### PR DESCRIPTION
this updates documentation to import **`configure`** from `bridge.framework.django`  instead of `bridge.django`

I'm aware that you are exposing django in the `__init__.py` like this:

> from bridge.framework import django
> __all__ = ["django"]

but that is not going to expose the `configure` function on `bridge.django` directly unless we are importing `django` like so:

> from bridge import django
> django.configure(locals())